### PR TITLE
feat: add more specific errors

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -4,23 +4,23 @@
 
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum Error {
-    #[allow(dead_code)]
-    #[error("Undefined error")]
-    /// The undefined error will be used as a placeholder for all other errors.
-    /// Two known errors that are currently undefined but need their own instance
-    /// in the future are an index out of bounds error and an integration error.
-    Undefined,
 
-    #[error("Argument passed was out of bounds")]
-    /// The value k = |(kx, ky)| can only be positive. If k <=0, the function will pass ArgumentOutOfBounds.
-    ArgumentOutOfBounds,
+   #[error("Argument passed was out of bounds")]
+   /// The value k = |(kx, ky)| can only be positive. If k <=0, the function will pass ArgumentOutOfBounds.
+   ArgumentOutOfBounds,
 
+   #[error("One or more of the points surrounding the nearest point are out of bounds.")]
+   /// This error is returned when `nearest_point` returns a point in bounds,
+   /// but `four_corners` is still out of bounds.
+   CornersOutOfBounds,
+   
     #[error("Argument passed was not a valid option")]
     /// The argument passed was not a valid option
     InvalidArgument,
 
     #[error("Index passed was out of bounds")]
-    /// The index is out of bounds of the array and would panic if attempted to access array.
+    /// The index is out of bounds of the array and would panic if attempted to
+   /// access array.
     IndexOutOfBounds,
 
     #[error(transparent)]
@@ -28,4 +28,9 @@ pub(crate) enum Error {
 
     #[error(transparent)]
     IntegrationError(#[from] ode_solvers::dop_shared::IntegrationError),
+
+    #[error("The requested point has no nearest point")]
+    /// The target point was either outside the domain or closest to the edge of
+    /// the domain.
+    NoNearestPoint,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,10 +78,8 @@ fn output_to_file(
     step_size: f64,
 ) -> Result<File, Error> {
     let mut stepper = Rk4::new(system, t0, y0, tf, step_size);
-    let res = stepper.integrate();
-    if res.is_err() {
-        return Err(Error::Undefined);
-    }
+    stepper.integrate()?;
+
     let y = stepper.y_out();
 
     let mut file = File::create("y_out.txt")?;


### PR DESCRIPTION
I added two more errors and deleted one from `error.rs`

I created `NoNearestPoint` error. This error is returned when the `nearest_point` method of `CartesianFile` returns `None`.

I created `CornersOutOfBounds` error. This error is returned when the `four_corners` method of `CartesianFile` returns `None`.

I deleted `Undefined` because there are now errors that handle out of bounds and integration.

Originally, I wanted to create an error for when the ray passed out of bounds, but I realized there is no way to know that based solely on whether the input x, y is out of bounds, since it could have been out of bounds from the beginning. So I created these two errors instead. Also, note that `NoNearestPoint` message will be displayed now when the ray exits the domain.