### PR TITLE
WIP: moving ArrayDepth to file in bathymetry

### DIFF
--- a/src/bathymetry/array_depth.rs
+++ b/src/bathymetry/array_depth.rs
@@ -1,0 +1,29 @@
+use super::BathymetryData;
+use crate::error::Error;
+
+pub(crate) struct ArrayDepth {
+    array: Vec<Vec<f32>>,
+}
+
+// FIXME: the program is not crashing, but NAN isn't that useful. maybe use option: some or none
+impl BathymetryData for ArrayDepth {
+    fn get_depth(&self, x: &f32, y: &f32) -> Result<f32, Error> {
+        if *x as usize >= self.array.len() || *y as usize >= self.array.len() {
+            return Ok(f32::NAN);
+        }
+        Ok(self.array[*x as usize][*y as usize]) // FIXME: since x and y are floats, they are truncated or rounded to a usize. I probably want a better interpolation estimate
+    }
+
+    fn get_depth_and_gradient(&self, x: &f32, y: &f32) -> Result<(f32, (f32, f32)), Error> {
+        if *x as usize >= self.array.len() || *y as usize >= self.array.len() {
+            return Ok((f32::NAN, (f32::NAN, f32::NAN)));
+        }
+        Ok((self.array[*x as usize][*y as usize], (0.0, 0.0)))
+    }
+}
+
+impl ArrayDepth {
+    pub(crate) fn new(array: Vec<Vec<f32>>) -> Self {
+        ArrayDepth { array }
+    }
+}

--- a/src/bathymetry/mod.rs
+++ b/src/bathymetry/mod.rs
@@ -1,10 +1,13 @@
 //! Bathymetry
 
+mod array_depth;
 mod cartesian;
 mod constant_depth;
 mod constant_slope;
 
 use crate::error::Error;
+#[allow(unused_imports)]
+pub(super) use array_depth::ArrayDepth;
 #[allow(unused_imports)]
 pub(super) use cartesian::CartesianFile;
 #[allow(unused_imports)]


### PR DESCRIPTION
I copied the `ArrayDepth` from `lib.rs` and moved it into its own file `bathymetry/array_depth.rs`. There needs to be tests for `ArrayDepth`. The struct itself also needs a lot improvement. After fixing, I can try to add default states with `derive_builder`, too, for a constant depth deep water array.