### PR TITLE
test: add check for zero depth

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,7 +176,7 @@ impl<'a> WaveRayPath<'a> {
 /// - If k is negative, group velocity will return this error.
 ///
 pub(crate) fn group_velocity(k: &f64, h: &f64) -> Result<f64, Error> {
-    if *h < 0.0 {
+    if *h <= 0.0 {
         return Ok(f64::NAN); // FIXME: should this also return an error?
     }
     if *k <= 0.0 {


### PR DESCRIPTION
On line 426, I added a test called `test_zero_h`. The test is almost a copy of the `test_zero_k` above, except k is positive and h is always zero. This test confirms that the output from a depth of zero is `NaN` since in the group velocity function, the `cg` term is calculated to be zero I think because of trying to divide by 0. If needed, we could introduce a new error like `DivideByZero` or `ZeroDepth` to differentiate this from the other errors, since there are many ways the program can give an output of `NaN`.