### PR TITLE
CurrentData trait with constant current implementation

### DIFF
--- a/src/current/constant_current.rs
+++ b/src/current/constant_current.rs
@@ -39,9 +39,27 @@ impl CurrentData for ConstantCurrent {
     /// `Result<(f64, f64), Error>` : returns the values (u, v) or an Error.
     ///
     /// # Error
-    /// The trait definition includes the chance for error. However,
+    /// The trait definition includes the chance for error. However, the
     /// `ConstantCurrent::current` should never return an error.
     fn current(&self, _x: &f64, _y: &f64) -> Result<(f64, f64), Error> {
         Ok((self.u, self.v))
+    }
+
+    /// get the current and gradient at point (x, y)
+    /// 
+    /// # Arguments
+    /// - `x` : `f64` the x location
+    /// 
+    /// - `y` : `f64` the y location
+    /// 
+    /// # Returns
+    /// `Result<((f64, f64), (f64, f64, f64, f64)), Error>` : returns the values
+    /// (u, v) and (du/dx, du/dy, dv/dx, dv/dy) or an Error.
+    /// 
+    /// # Error
+    /// The trait definition includes the chance for error. However, the
+    /// `ConstantCurrent::current_and_gradient` should never return an error.
+    fn current_and_gradient(&self, _x: &f64, _y: &f64) -> Result<((f64, f64), (f64, f64, f64, f64)), Error> {
+        Ok(((self.u, self.v), (0.0, 0.0, 0.0, 0.0)))
     }
 }

--- a/src/current/mod.rs
+++ b/src/current/mod.rs
@@ -14,4 +14,6 @@ pub(super) use constant_current::ConstantCurrent;
 pub(crate) trait CurrentData {
     /// Return the current (u, v) at the given (x, y)
     fn current(&self, x: &f64, y: &f64) -> Result<(f64, f64), Error>;
+    /// Return the current (u, v) and the gradient (du/dx, du/dy, dv/dx, dv/dy)
+    fn current_and_gradient(&self, x: &f64, y: &f64) -> Result<((f64, f64), (f64, f64, f64, f64)), Error>;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,9 +117,57 @@ impl<'a> WaveRayPath<'a> {
         Ok(h_dh)
     }
 
+    /// Get the current at the point (x, y)
+    ///
+    /// # Arguments
+    /// `x` : `&f64`
+    /// - the x coordinate in meters
+    ///
+    /// `y` : `&f64`
+    /// - the y coordinate in meters
+    ///
+    /// # Returns
+    /// `Result<(f64, f64), Error>`: returns either the current (u, v) at (x, y)
+    /// or an error
+    ///
+    /// # Errors
+    /// TODO: add errors. The current implementation with only constant current
+    /// should never return an error.
+    ///
+    /// # Panics
+    /// This will only panic if there is no current_data to unwrap.
     pub fn current(&self, x: &f64, y: &f64) -> Result<(f64, f64), Error> {
         let (u, v) = self.current_data.unwrap().current(x, y)?;
         Ok((u, v))
+    }
+
+    /// Get the current and gradient at the point (x, y)
+    ///
+    /// # Arguments
+    /// `x` : `&f64`
+    /// - the x coordinate in meters
+    ///
+    /// `y` : `&f64`
+    /// - the y coordinate in meters
+    ///
+    /// # Returns
+    /// `Result<(f64, f64, f64, f64, f64, f64), Error>`: returns either the
+    /// current (u, v) and the gradient (du/dx, du/dy, dv/dx, dv/dy) at (x, y)
+    ///
+    /// # Errors
+    /// TODO: add errors. The current implementation with only constant current
+    /// should never return an error.
+    ///
+    /// # Panics
+    /// This will only panic if there is no current_data to unwrap.
+    pub fn current_and_gradient(
+        &self,
+        x: &f64,
+        y: &f64,
+    ) -> Result<(f64, f64, f64, f64, f64, f64), Error> {
+        let ((u, v), (dudx, dudy, dvdx, dvdy)) =
+            self.current_data.unwrap().current_and_gradient(x, y)?;
+        Ok((u, v, dudx, dvdx, dudy, dvdy))
     }
 
     /// Calculates system of odes from the given state
@@ -165,8 +213,7 @@ impl<'a> WaveRayPath<'a> {
         let (u, v, dudx, dvdx, dudy, dvdy) = if self.current_data.is_none() {
             (0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
         } else {
-            let (a, b) = self.current(x, y)?;
-            (a, b, 0.0, 0.0, 0.0, 0.0)
+            self.current_and_gradient(x, y)?
         };
 
         let h = h as f64;
@@ -619,7 +666,7 @@ mod test_constant_bathymetry {
 mod test_current {
     use crate::{
         bathymetry::{BathymetryData, ConstantDepth},
-        current::{self, ConstantCurrent, CurrentData},
+        current::{ConstantCurrent, CurrentData},
         WaveRayPath,
     };
 


### PR DESCRIPTION
I started to work on the current equations, which I included in full in `odes`.

I first did a test case for constant current and constant depths, so that the equations are the simplest to test for.

I decided to write a simple ConstantCurrent struct and create a simple CurrentData trait. These will need to be refactored a lot, since I designed them specifically for the test case.

I also think the way I'm adding currents might have to be modified or refactored. I added to variables to the `WaveRayPath` for both x and y currents as Option<&'a dyn CurrentData>. I then created a second constructor that can accept the CurrentData trait instance. Then in the odes function, the current values are set to zero if none, or they are taken from a get_current function.

I was confused by adding current to the code we already have, and I think it will likely need to be refactored a lot. I will start on that next monday. But once we decide how this will integrate, setting up the dk/dt calculations should be easier.