### PR TITLE
Caching compiled crates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,10 @@ jobs:
           toolchain: stable
           override: true
 
+      - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
       - name: Run cargo check
         uses: actions-rs/cargo@v1
         with:
@@ -54,6 +58,10 @@ jobs:
           toolchain: ${{ matrix.rust }}
           override: true
 
+      - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
       - name: Run tests
         uses: actions-rs/cargo@v1
         with:
@@ -73,6 +81,10 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Make sure we can publish
         uses: actions-rs/cargo@v1


### PR DESCRIPTION
Tests are taking too long do download and compile all requirements on every workflow run. Let's cache the compiled crates to speed up the process.