### PR TITLE
Missing reference to repository URL

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 edition = "2021"
 documentation = "https://docs.rs/mantaray"
-repository = "https://github.com/mines-oceanography/ray_tracing"
+repository = "https://github.com/mines-oceanography/mantaray"
 rust-version = "1.76.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
This goes in the crate's reference.