### PR TITLE
Fixing bad CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,10 +67,10 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Run tests
-         uses: actions-rs/cargo@v1
-         with:
-           command: test
-           args: --no-fail-fast
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --no-fail-fast
 
       # OSX fails to cargo test with pixi environment.
       # Let's postpone this for now.


### PR DESCRIPTION
This is the reason why we shouldn't bypass the checks. A silly typo that breaks the CI.