### PR TITLE
Remove conda and main channels from pixi.toml

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Add a short description here"
 authors = ["Gui Castelao <guilherme@castelao.net>"]
 license = "MIT OR Apache-2.0"
-channels = ["conda-forge", "conda", "main"]
+channels = ["conda-forge"]
 platforms = ["osx-arm64", "linux-64", "win-64"]
 
 [tasks]


### PR DESCRIPTION
Removing `conda` and `main` from channels in `pixi.toml`. not rebuilding `pixi.lock` for now.