### PR TITLE
Fix pixi + MacOs test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.8.8
         with:
-          pixi-version: v0.45.0
+          pixi-version: v0.47.0
           cache: true
           frozen: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,16 +67,8 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Run tests
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --no-fail-fast
-
-      # OSX fails to cargo test with pixi environment.
-      # Let's postpone this for now.
-      # - name: Run tests
-      #   run: |
-      #     pixi run --frozen cargo test --no-fail-fast
+        run: |
+          pixi run --frozen cargo test --no-fail-fast
 
   publish:
     name: Publish (dry-run)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -471,6 +471,7 @@ dependencies = [
  "netcdf3",
  "ode_solvers",
  "pyo3",
+ "pyo3-build-config",
  "rayon",
  "serde",
  "serde_json",
@@ -755,11 +756,10 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.24.2"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5203598f366b11a02b13aa20cab591229ff0a89fd121a308a5df751d5fc9219"
+checksum = "f239d656363bcee73afef85277f1b281e8ac6212a1d42aa90e55b90ed43c47a4"
 dependencies = [
- "cfg-if",
  "indoc",
  "libc",
  "memoffset",
@@ -773,9 +773,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.24.2"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99636d423fa2ca130fa5acde3059308006d46f98caac629418e53f7ebb1e9999"
+checksum = "755ea671a1c34044fa165247aaf6f419ca39caa6003aee791a0df2713d8f1b6d"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -783,9 +783,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.24.2"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78f9cf92ba9c409279bc3305b5409d90db2d2c22392d443a87df3a1adad59e33"
+checksum = "fc95a2e67091e44791d4ea300ff744be5293f394f1bafd9f78c080814d35956e"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -793,9 +793,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.24.2"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b999cb1a6ce21f9a6b147dcf1be9ffedf02e0043aec74dc390f3007047cecd9"
+checksum = "a179641d1b93920829a62f15e87c0ed791b6c8db2271ba0fd7c2686090510214"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -805,9 +805,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.24.2"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "822ece1c7e1012745607d5cf0bcb2874769f0f7cb34c4cde03b9358eb9ef911a"
+checksum = "9dff85ebcaab8c441b0e3f7ae40a6963ecea8a9f5e74f647e33fcf5ec9a1e89e"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ ndarray = { version = "0.16.1", features = ["rayon"] }
 netcdf3 = "0.5.2"
 netcdf = {version = "0.11.0", features = ["static", "ndarray"]}
 ode_solvers = "0.4.0"
-pyo3 = { version = "0.24.2" }
+pyo3 = { version = "0.25.0", features = ["extension-module"] }
 rayon = "1.10.0"
 serde_json = "1.0.119"
 serde = {version="1.0", features=["derive"]}
@@ -44,6 +44,7 @@ tempfile = "3.19.1"
 
 [build-dependencies]
 cbindgen = { version = "0.28.0", optional = true }
+pyo3-build-config = "0.25.0"
 
 [features]
 capi = ["libc"]

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    pyo3_build_config::add_extension_module_link_args();
+}


### PR DESCRIPTION
I was running into some build errors when trying to run `cargo test` on a Mac OS in GHA. Hoping to find a fix, I went looking in this repo, only to find this:  https://github.com/mines-oceanography/mantaray/blob/a2c1af1fc5c96048ad83a80e26af833c1312c3e7/.github/workflows/ci.yml#L75-L79

😄 

Well anyways, I spent the morning digging around and eventually found [some instructions from PyO3](https://pyo3.rs/v0.17.2/building_and_distribution#macos). This ended up working for me, so I figured I could save someone else the time/headache.