### PR TITLE
fix: remove unused lockfile dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -447,12 +447,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lockfile"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be1cf190319c74ba3e45923624626ae2e43fe42ad7e60ff38ded81044c37630"
-
-[[package]]
 name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -465,7 +459,6 @@ dependencies = [
  "cbindgen",
  "derive_builder",
  "libc",
- "lockfile",
  "ndarray",
  "netcdf",
  "netcdf3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,6 @@ thiserror = "2.0.12"
 tracing = "0.1.41"
 
 [dev-dependencies]
-lockfile = "0.4.0"
 tempfile = "3.20.0"
 
 [build-dependencies]


### PR DESCRIPTION
The crate `lockfile` was not used anywhere, so this pr removes it.

closes #181